### PR TITLE
Fixed CinnXPStarkMenu colors

### DIFF
--- a/Windows XP Embedded/cinnamon/cinnamon.css
+++ b/Windows XP Embedded/cinnamon/cinnamon.css
@@ -1789,7 +1789,7 @@ The colour parameters are red, green, blue, and transparency or a name */
 * (if CinnXPStarkMenu is used, change some stuff, else use default)
 * ===================================================================*/
 .right-buttons-box {
-  background-color: #D3E5FA;
+  background-color: #2e75ad;
   padding: 8px;
   border: 0 solid #a7b8cc;
   border-left-width: 1px; }
@@ -1805,7 +1805,7 @@ The colour parameters are red, green, blue, and transparency or a name */
   /* Information, which is shown, if you select apps*/ }
 
 .starkmenu-favorites-box {
-  background-color: #ffffff;
+  background-color: #013c6b;
   border: 0px solid #ffffff; }
 
 .starkmenu-favorites-box .menu-favorites-button {
@@ -1815,10 +1815,10 @@ The colour parameters are red, green, blue, and transparency or a name */
   padding: 0px 0px 0px 0px; }
 
 .starkmenu-applications-inner-box {
-  background-color: #D3E5FA; }
+  background-color: #2e75ad; }
 
 .starkmenu-applications-box StScrollView {
-  background-color: #ffffff;
+  background-color: #013c6b;
   color: black; }
 
 .starkmenu-search-box {

--- a/Windows XP Royale Dark/cinnamon/cinnamon.css
+++ b/Windows XP Royale Dark/cinnamon/cinnamon.css
@@ -1789,7 +1789,7 @@ The colour parameters are red, green, blue, and transparency or a name */
 * (if CinnXPStarkMenu is used, change some stuff, else use default)
 * ===================================================================*/
 .right-buttons-box {
-  background-color: #D3E5FA;
+  background-color: #5a606f;
   padding: 8px;
   border: 0 solid #a7b8cc;
   border-left-width: 1px; }
@@ -1805,7 +1805,7 @@ The colour parameters are red, green, blue, and transparency or a name */
   /* Information, which is shown, if you select apps*/ }
 
 .starkmenu-favorites-box {
-  background-color: #ffffff;
+  background-color: #353f4d;
   border: 0px solid #ffffff; }
 
 .starkmenu-favorites-box .menu-favorites-button {
@@ -1815,10 +1815,10 @@ The colour parameters are red, green, blue, and transparency or a name */
   padding: 0px 0px 0px 0px; }
 
 .starkmenu-applications-inner-box {
-  background-color: #D3E5FA; }
+  background-color: #5a606f; }
 
 .starkmenu-applications-box StScrollView {
-  background-color: #ffffff;
+  background-color: #353f4d;
   color: black; }
 
 .starkmenu-search-box {

--- a/Windows XP Royale/cinnamon/cinnamon.css
+++ b/Windows XP Royale/cinnamon/cinnamon.css
@@ -1789,7 +1789,7 @@ The colour parameters are red, green, blue, and transparency or a name */
 * (if CinnXPStarkMenu is used, change some stuff, else use default)
 * ===================================================================*/
 .right-buttons-box {
-  background-color: #D3E5FA;
+  background-color: #5373bf;
   padding: 8px;
   border: 0 solid #a7b8cc;
   border-left-width: 1px; }
@@ -1805,7 +1805,7 @@ The colour parameters are red, green, blue, and transparency or a name */
   /* Information, which is shown, if you select apps*/ }
 
 .starkmenu-favorites-box {
-  background-color: #ffffff;
+  background-color: #10377c;
   border: 0px solid #ffffff; }
 
 .starkmenu-favorites-box .menu-favorites-button {
@@ -1815,10 +1815,10 @@ The colour parameters are red, green, blue, and transparency or a name */
   padding: 0px 0px 0px 0px; }
 
 .starkmenu-applications-inner-box {
-  background-color: #D3E5FA; }
+  background-color: #5373bf; }
 
 .starkmenu-applications-box StScrollView {
-  background-color: #ffffff;
+  background-color: #10377c;
   color: black; }
 
 .starkmenu-search-box {

--- a/Windows XP Zune/cinnamon/cinnamon.css
+++ b/Windows XP Zune/cinnamon/cinnamon.css
@@ -1789,7 +1789,7 @@ The colour parameters are red, green, blue, and transparency or a name */
 * (if CinnXPStarkMenu is used, change some stuff, else use default)
 * ===================================================================*/
 .right-buttons-box {
-  background-color: #D3E5FA;
+  background-color: #666666;
   padding: 8px;
   border: 0 solid #a7b8cc;
   border-left-width: 1px; }
@@ -1805,7 +1805,7 @@ The colour parameters are red, green, blue, and transparency or a name */
   /* Information, which is shown, if you select apps*/ }
 
 .starkmenu-favorites-box {
-  background-color: #ffffff;
+  background-color: #2f2f2f;
   border: 0px solid #ffffff; }
 
 .starkmenu-favorites-box .menu-favorites-button {
@@ -1815,11 +1815,17 @@ The colour parameters are red, green, blue, and transparency or a name */
   padding: 0px 0px 0px 0px; }
 
 .starkmenu-applications-inner-box {
-  background-color: #D3E5FA; }
+  background-color: #666666; }
 
 .starkmenu-applications-box StScrollView {
-  background-color: #ffffff;
+  background-color: #2f2f2f;
   color: black; }
+
+.starkmenu-background .menu-application-button-selected StLabel,
+.starkmenu-background .menu-category-button-selected StLabel, 
+.starkmenu-background .menu-favorites-button:hover StLabel {
+  color: black;
+}
 
 .starkmenu-search-box {
   padding-bottom: 5px; }


### PR DESCRIPTION
I fixed the CinnXPStarkMenu menu colors for the Royale, Royale Dark, Embedded and Zune themes. You can check how they look by installing CinnXPStarkMenu and adding the applet to the leftmost side of the panel and pressing the menu icon. The colors were picked from a high quality source so they should be close if not identical to the original theme colors.

Royale and Royale Noir:

<img width="543" height="632" alt="royale noir millenium ie7" src="https://github.com/user-attachments/assets/13bb28f7-f1db-4496-b606-ffb213a98bc1" />
<img width="529" height="629" alt="royale ie7 file explorer" src="https://github.com/user-attachments/assets/48d7f938-79a0-4e5e-a912-149b0d282d7e" />
